### PR TITLE
Move from rubin-sim to rubin-scheduler

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -13,6 +13,8 @@ build:
 test:
   requires:
     - ts-conda-build =0.3
+    - astropy
+    - palpy
     - rubin-scheduler
     - ts-dateloc
   source_files:
@@ -39,5 +41,7 @@ requirements:
     - python {{ python }}
     - setuptools
     - setuptools_scm
+    - astropy
+    - palpy
     - rubin-scheduler
     - ts-dateloc

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -13,7 +13,7 @@ build:
 test:
   requires:
     - ts-conda-build =0.3
-    - rubin-sim >=1
+    - rubin-scheduler
     - ts-dateloc
   source_files:
     - python
@@ -39,5 +39,5 @@ requirements:
     - python {{ python }}
     - setuptools
     - setuptools_scm
-    - rubin-sim >=1
+    - rubin-scheduler
     - ts-dateloc


### PR DESCRIPTION
This moves from rubin_sim.skybrightnes_pre to rubin_scheduler.skybrightness_pre 
It removes the "calculation" of airmass by rubin_sim (which only returned the airmass grid points for the skybrightness values). 

This ticket also takes care of [DM-40997](https://jira.lsstcorp.org/browse/DM-40997) by adding a "skybrightness" timestamp which is expected to remain within the skybrightness_pre files downloaded as part of the small set of test files by rubin_scheduler. 